### PR TITLE
Bump to latest actions versions, hash-pinned

### DIFF
--- a/.github/workflows/build-generic.yml
+++ b/.github/workflows/build-generic.yml
@@ -29,12 +29,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b #v4.5.0
         with:
           java-version: 17
 
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
 
       - name: Build with Maven
         run: mvn --batch-mode -Pjacoco verify

--- a/.github/workflows/patch-generic.yml
+++ b/.github/workflows/patch-generic.yml
@@ -39,12 +39,12 @@ jobs:
           private-key: ${{ secrets.githubappPrivateKey }}
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b #v4.5.0
         with:
           java-version: 17
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-generic.yml
+++ b/.github/workflows/release-generic.yml
@@ -42,12 +42,12 @@ jobs:
           private-key: ${{ secrets.githubappPrivateKey }}
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@8df1039502a15bceb9433410b1a100fbe190c53b #v4.5.0
         with:
           java-version: 17
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem?**
No

**What kind of change does this PR introduce?**
Dependency update

**What is the current behavior?**
Actions with old version, not pinned
- setup-java@v1 using deprecated node12
- checkout@v1 using deprecated node12, or checkout@v4

**What is the new behavior (if this is a feature change)?**
- setup-java v4.5.0, version pinned by hash
- checkout v4.2.2, version pinned by hash

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No