### PR TITLE
Use github environments to restrict secrets access to authorized (reviewed) workflows

### DIFF
--- a/.github/workflows/build-backend-app-generic.yml
+++ b/.github/workflows/build-backend-app-generic.yml
@@ -20,10 +20,14 @@ on:
       eventType:
         required: true
         type: string
+      environment:
+        required: false
+        default: 'release'
+        type: string
     secrets:
       sonar-token:
         required: true
-      docker-token:
+      DOCKERHUB_TOKEN:
         required: true
       repo-token:
         required: true
@@ -31,6 +35,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref == 'refs/heads/main' && inputs.environment || '' }}
     steps:
       - name: Set up JDK 21
         uses: actions/setup-java@v1
@@ -60,7 +66,7 @@ jobs:
           -Djib.httpTimeout=60000
           -Djib.to.image=${{ inputs.dockerImage }}
           -Djib.to.auth.username=${{ inputs.dockerUsername }}
-          -Djib.to.auth.password=${{ secrets.docker-token }}
+          -Djib.to.auth.password=${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Broadcast update event
         if: github.ref == 'refs/heads/main'

--- a/.github/workflows/build-base-docker-image-generic.yml
+++ b/.github/workflows/build-base-docker-image-generic.yml
@@ -7,6 +7,9 @@ on:
       dockerUsername:
         required: true
         type: string
+      dockerRoUsername:
+        required: true
+        type: string
       eventOrganizations:
         required: false
         default: ''
@@ -15,7 +18,9 @@ on:
         required: true
         type: string
     secrets:
-      docker-token:
+      DOCKERHUB_TOKEN:
+        required: true
+      docker-ro-token:
         required: true
       repo-token:
         required: true
@@ -23,6 +28,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ github.ref == 'refs/heads/main' && inputs.environment || '' }}
     steps:
       - name: Checkout sources
         uses: actions/checkout@v1
@@ -31,8 +38,8 @@ jobs:
         uses: elgohr/Publish-Docker-Github-Action@33a481be3e179353cb7793a92b57cf9a6c985860 # v4
         with:
           name: ${{ inputs.dockerImage }}
-          username: ${{ inputs.dockerUsername }}
-          password: ${{ secrets.docker-token }}
+          username: ${{ github.ref != 'refs/heads/main' && inputs.dockerRoUsername || inputs.dockerUsername }}
+          password: ${{ github.ref != 'refs/heads/main' && secrets.docker-ro-token || secrets.DOCKERHUB_TOKEN }}
           no_push: ${{ github.ref != 'refs/heads/main' }}
           tags: "latest"
 

--- a/.github/workflows/build-base-docker-image-generic.yml
+++ b/.github/workflows/build-base-docker-image-generic.yml
@@ -17,6 +17,10 @@ on:
       eventType:
         required: true
         type: string
+      environment:
+        required: false
+        default: 'release'
+        type: string
     secrets:
       DOCKERHUB_TOKEN:
         required: true

--- a/.github/workflows/build-base-docker-image-generic.yml
+++ b/.github/workflows/build-base-docker-image-generic.yml
@@ -5,9 +5,11 @@ on:
         required: true
         type: string
       dockerUsername:
+        description: 'Used to write latest images after the PR is merged in main'
         required: true
         type: string
       dockerRoUsername:
+        description: 'Used to read the images (FROM: clause in the Dockerfile) to test the Dockerfile in the PR'
         required: true
         type: string
       eventOrganizations:

--- a/.github/workflows/patch-backend-app-generic.yml
+++ b/.github/workflows/patch-backend-app-generic.yml
@@ -19,24 +19,30 @@ on:
       releaseVersion:
         required: true
         type: string
+      environment:
+        required: false
+        default: 'release'
+        type: string
     secrets:
-      githubappPrivateKey:
+      VERSIONBUMP_GHAPP_PRIVATE_KEY:
         required: true
       sonar-token:
         required: true
-      docker-token:
+      DOCKERHUB_TOKEN:
         required: true
 
 jobs:
   patch:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token
         name: Generate app token
         with:
           app-id: ${{ inputs.githubappId }}
-          private-key: ${{ secrets.githubappPrivateKey }}
+          private-key: ${{ secrets.VERSIONBUMP_GHAPP_PRIVATE_KEY }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v1
@@ -122,7 +128,7 @@ jobs:
           -Djib.httpTimeout=60000
           -Djib.to.image=${{ inputs.dockerImage }}:${{ env.GITHUB_SHORT_VERSION }}
           -Djib.to.auth.username=${{ inputs.dockerUsername }}
-          -Djib.to.auth.password=${{ secrets.docker-token }}
+          -Djib.to.auth.password=${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push release branch and tag
         run: |

--- a/.github/workflows/patch-backend-lib-generic.yml
+++ b/.github/workflows/patch-backend-lib-generic.yml
@@ -8,13 +8,19 @@ on:
         description: 'Patch branch (format: release-vX.Y.Z)'
         required: true
         type: string
+      environment:
+        required: false
+        default: 'release'
+        type: string
     secrets:
-      githubappPrivateKey:
+      VERSIONBUMP_GHAPP_PRIVATE_KEY:
         required: true
 
 jobs:
   patch:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
     steps:
       - name: Validate branch name format
         run: |
@@ -28,7 +34,7 @@ jobs:
         name: Generate app token
         with:
           app-id: ${{ inputs.githubappId }}
-          private-key: ${{ secrets.githubappPrivateKey }}
+          private-key: ${{ secrets.VERSIONBUMP_GHAPP_PRIVATE_KEY }}
 
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/patch-base-docker-image-generic.yml
+++ b/.github/workflows/patch-base-docker-image-generic.yml
@@ -13,22 +13,28 @@ on:
       releaseVersion:
         required: true
         type: string
+      environment:
+        required: false
+        default: 'release'
+        type: string
     secrets:
-      githubappPrivateKey:
+      VERSIONBUMP_GHAPP_PRIVATE_KEY:
         required: true
-      docker-token:
+      DOCKERHUB_TOKEN:
         required: true
 
 jobs:
   patch:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token
         name: Generate app token
         with:
           app-id: ${{ inputs.githubappId }}
-          private-key: ${{ secrets.githubappPrivateKey }}
+          private-key: ${{ secrets.VERSIONBUMP_GHAPP_PRIVATE_KEY }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -91,7 +97,7 @@ jobs:
         with:
           name: ${{ inputs.dockerImage }}
           username: ${{ inputs.dockerUsername }}
-          password: ${{ secrets.docker-token }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
           tags: ${{ env.GITHUB_SHORT_VERSION }}
 
       - name: Push release branch and tag

--- a/.github/workflows/patch-frontend-app-generic.yml
+++ b/.github/workflows/patch-frontend-app-generic.yml
@@ -16,10 +16,14 @@ on:
         description: 'GitHub App ID for authentication'
         required: true
         type: string
+      environment:
+        required: false
+        default: 'release'
+        type: string
     secrets:
-      githubappPrivateKey:
+      VERSIONBUMP_GHAPP_PRIVATE_KEY:
         required: true
-      docker-token:
+      DOCKERHUB_TOKEN:
         required: true
       sonar-token:
         required: true
@@ -30,13 +34,15 @@ env:
 jobs:
   patch:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
     steps:
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ inputs.githubappId }}
-          private-key: ${{ secrets.githubappPrivateKey }}
+          private-key: ${{ secrets.VERSIONBUMP_GHAPP_PRIVATE_KEY }}
 
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -120,7 +126,7 @@ jobs:
         with:
           name: ${{ inputs.dockerImage }}
           username: ${{ inputs.dockerUsername }}
-          password: ${{ secrets.docker-token }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
           tags: ${{ env.RELEASE_VERSION }}
 
       - name: Push tag and release branch

--- a/.github/workflows/release-backend-app-generic.yml
+++ b/.github/workflows/release-backend-app-generic.yml
@@ -22,24 +22,30 @@ on:
       gitReference:
         required: true
         type: string
+      environment:
+        required: false
+        default: 'release'
+        type: string
     secrets:
-      githubappPrivateKey:
+      VERSIONBUMP_GHAPP_PRIVATE_KEY:
         required: true
       sonar-token:
         required: true
-      docker-token:
+      DOCKERHUB_TOKEN:
         required: true
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token
         name: Generate app token
         with:
           app-id: ${{ inputs.githubappId }}
-          private-key: ${{ secrets.githubappPrivateKey }}
+          private-key: ${{ secrets.VERSIONBUMP_GHAPP_PRIVATE_KEY }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@v1
@@ -108,7 +114,7 @@ jobs:
           -Djib.httpTimeout=60000
           -Djib.to.image=${{ inputs.dockerImage }}:${{ env.GITHUB_SHORT_VERSION }}
           -Djib.to.auth.username=${{ inputs.dockerUsername }}
-          -Djib.to.auth.password=${{ secrets.docker-token }}
+          -Djib.to.auth.password=${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Push release branch and tag
         run: |

--- a/.github/workflows/release-backend-lib-generic.yml
+++ b/.github/workflows/release-backend-lib-generic.yml
@@ -8,13 +8,19 @@ on:
         description: 'Version type increment (major | minor)'
         required: true
         type: string
+      environment:
+        required: false
+        default: 'release'
+        type: string
     secrets:
-      githubappPrivateKey:
+      VERSIONBUMP_GHAPP_PRIVATE_KEY:
         required: true
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
     steps:
       - name: Validate Version Type
         run: |
@@ -29,7 +35,7 @@ jobs:
         name: Generate app token
         with:
           app-id: ${{ inputs.githubappId }}
-          private-key: ${{ secrets.githubappPrivateKey }}
+          private-key: ${{ secrets.VERSIONBUMP_GHAPP_PRIVATE_KEY }}
 
       - name: Checkout sources
         uses: actions/checkout@v4

--- a/.github/workflows/release-base-docker-image-generic.yml
+++ b/.github/workflows/release-base-docker-image-generic.yml
@@ -16,22 +16,28 @@ on:
       gitReference:
         required: true
         type: string
+      environment:
+        required: false
+        default: 'release'
+        type: string
     secrets:
-      githubappPrivateKey:
+      VERSIONBUMP_GHAPP_PRIVATE_KEY:
         required: true
-      docker-token:
+      DOCKERHUB_TOKEN:
         required: true
 
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
     steps:
       - uses: actions/create-github-app-token@v1
         id: app-token
         name: Generate app token
         with:
           app-id: ${{ inputs.githubappId }}
-          private-key: ${{ secrets.githubappPrivateKey }}
+          private-key: ${{ secrets.VERSIONBUMP_GHAPP_PRIVATE_KEY }}
 
       - name: Checkout sources
         uses: actions/checkout@v4
@@ -77,7 +83,7 @@ jobs:
         with:
           name: ${{ inputs.dockerImage }}
           username: ${{ inputs.dockerUsername }}
-          password: ${{ secrets.docker-token }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
           tags: ${{ env.GITHUB_SHORT_VERSION }}
 
       - name: Push release branch and tag

--- a/.github/workflows/release-frontend-app-generic.yml
+++ b/.github/workflows/release-frontend-app-generic.yml
@@ -20,10 +20,14 @@ on:
         description: 'GitHub App ID for authentication'
         required: true
         type: string
+      environment:
+        required: false
+        default: 'release'
+        type: string
     secrets:
-      githubappPrivateKey:
+      VERSIONBUMP_GHAPP_PRIVATE_KEY:
         required: true
-      docker-token:
+      DOCKERHUB_TOKEN:
         required: true
       sonar-token:
         required: true
@@ -34,13 +38,15 @@ env:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
     steps:
       - name: Generate GitHub App Token
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ inputs.githubappId }}
-          private-key: ${{ secrets.githubappPrivateKey }}
+          private-key: ${{ secrets.VERSIONBUMP_GHAPP_PRIVATE_KEY }}
 
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -104,7 +110,7 @@ jobs:
         with:
           name: ${{ inputs.dockerImage }}
           username: ${{ inputs.dockerUsername }}
-          password: ${{ secrets.docker-token }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
           tags: ${{ env.RELEASE_VERSION }}
 
       - name: Push release branch and tag

--- a/.github/workflows/release-frontend-lib-generic.yml
+++ b/.github/workflows/release-frontend-lib-generic.yml
@@ -13,8 +13,12 @@ on:
         description: 'GitHub App ID for authentication'
         required: true
         type: string
+      environment:
+        required: false
+        default: 'release'
+        type: string
     secrets:
-      githubappPrivateKey:
+      VERSIONBUMP_GHAPP_PRIVATE_KEY:
         required: true
 
 permissions:
@@ -23,6 +27,8 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment:
+      name: ${{ inputs.environment }}
     steps:
       - name: Validate Version Type
         run: |
@@ -43,7 +49,7 @@ jobs:
         uses: actions/create-github-app-token@v1
         with:
           app-id: ${{ inputs.githubappId }}
-          private-key: ${{ secrets.githubappPrivateKey }}
+          private-key: ${{ secrets.VERSIONBUMP_GHAPP_PRIVATE_KEY }}
 
       - name: Checkout Repository
         uses: actions/checkout@v4


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
NO


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->
unsecure releases


**What is the new behavior (if this is a feature change)?**
secure releases


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
As per https://github.com/actions/runner/issues/998 and https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#example-using-environment-name-and-url
  environment: blah exists for short form notations, and it doesn't support contexts.
but
  environment:
    name: an expression is allowed here

As per https://github.com/orgs/community/discussions/25238#discussioncomment-3247035, the secret names need to match between the environment at the caller and the reusable workflow:
> I was finally able to get a solution/clarification from GitHub support. This is
> what’s happening (and is the intended functionality of GitHub Actions). The
> last line in the parent script, “TEST_SECRET: ${{ secrets.TEST_SECRET }}” is
> granting access to the child script to read the value TEST_SECRET. It is not
> actually passing the value because TEST_SECRET is not in scope at this point in
> the code and is therefor an empty string. Since it’s being passed in however,
> when the “environment: TestEnvironment” line is run in the child workflow, it
> populates that secret with the environment’s value and can be used in the
> associated steps.

and rename GITHUB_APP_PRIVATE_KEY to VERSIONBUMP_GHAPP_PRIVATE_KEY because secrets can't start with "GITHUB" and better reflect what the app actually does.
