### PR TITLE
Pin all actions to hashes

### DIFF
--- a/.github/workflows/build-backend-app-generic.yml
+++ b/.github/workflows/build-backend-app-generic.yml
@@ -39,12 +39,12 @@ jobs:
       name: ${{ github.ref == 'refs/heads/main' && inputs.environment || '' }}
     steps:
       - name: Set up JDK 21
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1 v1.4.4
         with:
           java-version: 21
 
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1 v1.2.0
 
       - name: Build with Maven
         run: mvn --batch-mode -Pjacoco verify
@@ -76,7 +76,7 @@ jobs:
 
       - name: Broadcast update event
         if: github.ref == 'refs/heads/main'
-        uses: gridsuite/broadcast-event@main
+        uses: gridsuite/broadcast-event@67201bc793618876822097ce2152b23b496a8227 # main
         with:
           token: ${{ secrets.repo-token }}
           organizations: ${{ inputs.eventOrganizations }}

--- a/.github/workflows/build-backend-lib-generic.yml
+++ b/.github/workflows/build-backend-lib-generic.yml
@@ -25,12 +25,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Set up JDK 21
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1 v1.4.4
         with:
           java-version: 21
 
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1 v1.2.0
 
       - name: Build with Maven
         run: mvn --batch-mode -Pjacoco verify
@@ -47,7 +47,7 @@ jobs:
 
       - name: Broadcast update event
         if: github.ref == 'refs/heads/main'
-        uses: gridsuite/broadcast-event@main
+        uses: gridsuite/broadcast-event@67201bc793618876822097ce2152b23b496a8227 # main
         with:
           token: ${{ secrets.repo-token }}
           organizations: ${{ inputs.eventOrganizations }}

--- a/.github/workflows/build-base-docker-image-generic.yml
+++ b/.github/workflows/build-base-docker-image-generic.yml
@@ -38,7 +38,7 @@ jobs:
       name: ${{ github.ref == 'refs/heads/main' && inputs.environment || '' }}
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v1
+        uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1 v1.2.0
 
       - name: Build and publish Docker image
         uses: elgohr/Publish-Docker-Github-Action@33a481be3e179353cb7793a92b57cf9a6c985860 # v4
@@ -51,7 +51,7 @@ jobs:
 
       - name: Broadcast update event
         if: github.ref == 'refs/heads/main'
-        uses: gridsuite/broadcast-event@main
+        uses: gridsuite/broadcast-event@67201bc793618876822097ce2152b23b496a8227 # main
         with:
           token: ${{ secrets.repo-token }}
           organizations: ${{ inputs.eventOrganizations }}

--- a/.github/workflows/patch-backend-app-generic.yml
+++ b/.github/workflows/patch-backend-app-generic.yml
@@ -63,7 +63,7 @@ jobs:
 
       # TODO make a composite action for the next steps to setup git (unless create-github-app-token incorporates all this...)
       # Copied from create-github-app-token README "Configure git CLI for an app's bot user"
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1 v1.11.6
         id: app-token
         name: Generate app token
         with:
@@ -84,12 +84,12 @@ jobs:
           RUNGHA_USER_ID: ${{ steps.get-user-id.outputs.user-id }} # just for defense against script injection
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1 v1.4.4
         with:
           java-version: 21
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4 v4.2.2
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/patch-backend-lib-generic.yml
+++ b/.github/workflows/patch-backend-lib-generic.yml
@@ -57,7 +57,7 @@ jobs:
 
       # TODO make a composite action for the next steps to setup git (unless create-github-app-token incorporates all this...)
       # Copied from create-github-app-token README "Configure git CLI for an app's bot user"
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1 v1.11.6
         id: app-token
         name: Generate app token
         with:
@@ -78,14 +78,14 @@ jobs:
           RUNGHA_USER_ID: ${{ steps.get-user-id.outputs.user-id }} # just for defense against script injection
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4 v4.2.2
         with:
           token: ${{ steps.app-token.outputs.token }}
           ref: ${{ inputs.branchRef }}
           fetch-depth: 0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1 v1.4.4
         with:
           java-version: 21
 

--- a/.github/workflows/patch-base-docker-image-generic.yml
+++ b/.github/workflows/patch-base-docker-image-generic.yml
@@ -55,7 +55,7 @@ jobs:
 
       # TODO make a composite action for the next steps to setup git (unless create-github-app-token incorporates all this...)
       # Copied from create-github-app-token README "Configure git CLI for an app's bot user"
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1 v1.11.6
         id: app-token
         name: Generate app token
         with:
@@ -76,7 +76,7 @@ jobs:
           RUNGHA_USER_ID: ${{ steps.get-user-id.outputs.user-id }} # just for defense against script injection
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4 v4.2.2
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/patch-frontend-app-generic.yml
+++ b/.github/workflows/patch-frontend-app-generic.yml
@@ -65,7 +65,7 @@ jobs:
       # Copied from create-github-app-token README "Configure git CLI for an app's bot user"
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1 v1.11.6
         with:
           app-id: ${{ inputs.githubappId }}
           private-key: ${{ secrets.VERSIONBUMP_GHAPP_PRIVATE_KEY }}
@@ -84,13 +84,13 @@ jobs:
           RUNGHA_USER_ID: ${{ steps.get-user-id.outputs.user-id }} # just for defense against script injection
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4 v4.2.2
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4 v4.3.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -160,7 +160,7 @@ jobs:
         run: npm run build
 
       - name: SonarCloud Analysis
-        uses: SonarSource/sonarcloud-github-action@v3.0.0
+        uses: SonarSource/sonarcloud-github-action@eb211723266fe8e83102bac7361f0a05c3ac1d1b # v3.0.0
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           SONAR_TOKEN: ${{ secrets.sonar-token }}

--- a/.github/workflows/release-backend-app-generic.yml
+++ b/.github/workflows/release-backend-app-generic.yml
@@ -66,7 +66,7 @@ jobs:
 
       # TODO make a composite action for the next steps to setup git (unless create-github-app-token incorporates all this...)
       # Copied from create-github-app-token README "Configure git CLI for an app's bot user"
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1 v1.11.6
         id: app-token
         name: Generate app token
         with:
@@ -87,12 +87,12 @@ jobs:
           RUNGHA_USER_ID: ${{ steps.get-user-id.outputs.user-id }} # just for defense against script injection
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1 v1.4.4
         with:
           java-version: 21
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4 v4.2.2
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-backend-lib-generic.yml
+++ b/.github/workflows/release-backend-lib-generic.yml
@@ -58,7 +58,7 @@ jobs:
 
       # TODO make a composite action for the next steps to setup git (unless create-github-app-token incorporates all this...)
       # Copied from create-github-app-token README "Configure git CLI for an app's bot user"
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1 v1.11.6
         id: app-token
         name: Generate app token
         with:
@@ -79,13 +79,13 @@ jobs:
           RUNGHA_USER_ID: ${{ steps.get-user-id.outputs.user-id }} # just for defense against script injection
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4 v4.2.2
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@b6e674f4b717d7b0ae3baee0fbe79f498905dfde # v1 v1.4.4
         with:
           java-version: 21
 

--- a/.github/workflows/release-base-docker-image-generic.yml
+++ b/.github/workflows/release-base-docker-image-generic.yml
@@ -58,7 +58,7 @@ jobs:
 
       # TODO make a composite action for the next steps to setup git (unless create-github-app-token incorporates all this...)
       # Copied from create-github-app-token README "Configure git CLI for an app's bot user"
-      - uses: actions/create-github-app-token@v1
+      - uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1 v1.11.6
         id: app-token
         name: Generate app token
         with:
@@ -79,7 +79,7 @@ jobs:
           RUNGHA_USER_ID: ${{ steps.get-user-id.outputs.user-id }} # just for defense against script injection
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4 v4.2.2
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-frontend-app-generic.yml
+++ b/.github/workflows/release-frontend-app-generic.yml
@@ -69,7 +69,7 @@ jobs:
       # Copied from create-github-app-token README "Configure git CLI for an app's bot user"
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1 v1.11.6
         with:
           app-id: ${{ inputs.githubappId }}
           private-key: ${{ secrets.VERSIONBUMP_GHAPP_PRIVATE_KEY }}
@@ -88,13 +88,13 @@ jobs:
           RUNGHA_USER_ID: ${{ steps.get-user-id.outputs.user-id }} # just for defense against script injection
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4 v4.2.2
         with:
           fetch-depth: 0
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4 v4.3.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -184,7 +184,7 @@ jobs:
         run: npm run build
 
       - name: SonarCloud Analysis
-        uses: SonarSource/sonarcloud-github-action@v3.0.0
+        uses: SonarSource/sonarcloud-github-action@eb211723266fe8e83102bac7361f0a05c3ac1d1b # v3.0.0
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           SONAR_TOKEN: ${{ secrets.sonar-token }}

--- a/.github/workflows/release-frontend-lib-generic.yml
+++ b/.github/workflows/release-frontend-lib-generic.yml
@@ -76,7 +76,7 @@ jobs:
       # Copied from create-github-app-token README "Configure git CLI for an app's bot user"
       - name: Generate GitHub App Token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@21cfef2b496dd8ef5b904c159339626a10ad380e # v1 v1.11.6
         with:
           app-id: ${{ inputs.githubappId }}
           private-key: ${{ secrets.VERSIONBUMP_GHAPP_PRIVATE_KEY }}
@@ -95,13 +95,13 @@ jobs:
           RUNGHA_USER_ID: ${{ steps.get-user-id.outputs.user-id }} # just for defense against script injection
 
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4 v4.2.2
         with:
           token: ${{ steps.app-token.outputs.token }}
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4 v4.3.0
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
NO


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
actions are not hash pinned


**What is the new behavior (if this is a feature change)?**
actions are hash pinned


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
For broadcast event, even though we write the code code, it's not updated often
so it's not too much maintenance to pin it.

For actions/* from github we could choose not to pin them, because github
provides the runner and it's not possible to pin the runner. But it's
simpler to just pin everything, and we don't update them very often anyway,
and even without pinning you still have to update them for major releases.
If it prooves to be too much maintenance, we could unpin them or we could
use bots like dependabot or renovate to automate upgrading.

Note: I didn't upgrade anything, just pinned it to today's hash. Will update in a separate PR

 