### PR TITLE
frontend-app-generic, use the normal GITHUB_TOKEN

### DIFF
--- a/.github/workflows/patch-frontend-app-generic.yml
+++ b/.github/workflows/patch-frontend-app-generic.yml
@@ -112,7 +112,7 @@ jobs:
       - name: SonarCloud Analysis
         uses: SonarSource/sonarcloud-github-action@v3.0.0
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.sonar-token }}
 
       - name: Build and publish Docker image

--- a/.github/workflows/release-frontend-app-generic.yml
+++ b/.github/workflows/release-frontend-app-generic.yml
@@ -96,7 +96,7 @@ jobs:
       - name: SonarCloud Analysis
         uses: SonarSource/sonarcloud-github-action@v3.0.0
         env:
-          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.sonar-token }}
 
       - name: Build and publish Docker image


### PR DESCRIPTION
Like everywhere else, no reason to use the app token for sonar

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
NO


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
chore


**What is the current behavior?**
<!-- You can also link to an open issue here -->
uses app token for sonar


**What is the new behavior (if this is a feature change)?**
uses normal simple GITHUB_TOKEN for sonar


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
