### PR TITLE
Lint is already done during build

### DIFF
--- a/.github/workflows/patch-frontend-app-generic.yml
+++ b/.github/workflows/patch-frontend-app-generic.yml
@@ -152,7 +152,6 @@ jobs:
 
       - name: Quality Checks
         run: |
-          npm run lint
           npm run test:coverage
           npm run licenses-check
 

--- a/.github/workflows/release-frontend-app-generic.yml
+++ b/.github/workflows/release-frontend-app-generic.yml
@@ -176,7 +176,6 @@ jobs:
 
       - name: Quality Checks
         run: |
-          npm run lint
           npm run test:coverage
           npm run licenses-check
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No.


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
remove duplicate lint in some pipelines


**What is the current behavior?**
<!-- You can also link to an open issue here -->
linter (eslint + prettier) is run twice: manually and during Vite's build


**What is the new behavior (if this is a feature change)?**
the linter is run only during Vite build


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
Nothing.


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
A build quicker by seconds!