### PR TITLE
Releases: allow all commits that don't silently omit other released commits

### DIFF
--- a/.github/workflows/release-backend-app-generic.yml
+++ b/.github/workflows/release-backend-app-generic.yml
@@ -141,7 +141,7 @@ jobs:
           # NOTE: needs fetch-depth: 0
           all_release_tags=$(git tag --list 'v[0-9]*')
           if [[ -z "$all_release_tags" ]]; then
-            echo "WARN no existing release tags found, is this the first release ?"
+            echo "WARN no existing release tags found, is this the first release?"
             if ! git_reference_parsed=$(git rev-parse "$RUNGHA_GIT_REFERENCE"); then
               echo "ERROR rev-parsing gitRef $RUNGHA_GIT_REFERENCE"
               exit 1

--- a/.github/workflows/release-backend-app-generic.yml
+++ b/.github/workflows/release-backend-app-generic.yml
@@ -127,21 +127,43 @@ jobs:
       # TODO deduplicate this code when github actions allows to easily share a script used
       # by reusable workflows. Currently only the workflow file is checked out at the caller
       # There are no good workarounds to checkout a companion file (script or composite action)
-      - name: Check if gitReference is already released
+      - name: Check if gitReference is missing already released commits
         run: |
-          # needs fetch-depth: 0
-          # This ensures that an old commit (potentially with a security issue) can not be rereleased
-          # as a new version (thus potentially restoring a security issue). This will not block regular
-          # releases because there is always at least the version bump commit in a real new release even if
-          # we are just rereleasing the same code with a new name as part of a global release.
-          if ! release_tags=$(git tag --contains "$RUNGHA_GIT_REFERENCE" 'v[0-9]*'); then
-            echo "ERROR checking whether gitRef $RUNGHA_GIT_REFERENCE is already released or not."
-            exit 1
-          elif [ -n "$release_tags" ]; then
-            echo "ERROR: gitRef $RUNGHA_GIT_REFERENCE already released: $release_tags"
-            exit 1
+          # This ensures that we don't silently drop commits (such as security fixes) by
+          # rereleasing as new version an old commit that was already released. Another
+          # possibility is to use a non linear history and branch from an old commit
+          # and merge to the tip of main, but then release the new branched commit (which
+          # was not already rereleased, but which also doesn't contain the recent commits)
+          # If the code that finds existing releases fails and doesn't find anything, it
+          # could be the first release, or it could be that there is a bug or exploit. In
+          # this case, instead of allowing to release anything, we just allow to release the
+          # tip of main (allowing to release anything would allow to drop commits).
+          # NOTE: needs fetch-depth: 0
+          all_release_tags=$(git tag --list 'v[0-9]*')
+          if [[ -z "$all_release_tags" ]]; then
+            echo "WARN no existing release tags found, is this the first release ?"
+            if ! git_reference_parsed=$(git rev-parse "$RUNGHA_GIT_REFERENCE"); then
+              echo "ERROR rev-parsing gitRef $RUNGHA_GIT_REFERENCE"
+              exit 1
+            fi
+            if ! main_parsed=$(git rev-parse origin/main); then
+              echo "ERROR rev-parsing origin/main"
+              exit 1
+            fi
+            if [[ -n "$git_reference_parsed" && "$git_reference_parsed" != "$main_parsed" ]]; then
+              echo "ERROR: No existing release found, must release the tip of main $main_parsed but got $git_reference_parsed"
+              exit 1
+            else
+              echo "gitRef $RUNGHA_GIT_REFERENCE is tip of main, release will be performed"
+            fi
           else
-            echo "gitRef $RUNGHA_GIT_REFERENCE never released, release will be performed"
+            latest_main_release=$(git merge-base main $all_release_tags)
+            if ! git merge-base --is-ancestor "$latest_main_release" "$RUNGHA_GIT_REFERENCE"; then
+              echo "ERROR gitRef $RUNGHA_GIT_REFERENCE is not a descendant of the latest released commit $latest_main_release"
+              exit 1
+            else
+              echo "gitRef $RUNGHA_GIT_REFERENCE descends from previous releases, release will be performed"
+            fi
           fi
         env:
           RUNGHA_GIT_REFERENCE: ${{ inputs.gitReference }} # just for defense against script injection

--- a/.github/workflows/release-backend-app-generic.yml
+++ b/.github/workflows/release-backend-app-generic.yml
@@ -137,7 +137,7 @@ jobs:
           # If the code that finds existing releases fails and doesn't find anything, it
           # could be the first release, or it could be that there is a bug or exploit. In
           # this case, instead of allowing to release anything, we just allow to release the
-          # tip of main (allowing to release anything would allow to drop commits).
+          # tip of main (allowing to release anything else would allow to drop commits).
           # NOTE: needs fetch-depth: 0
           all_release_tags=$(git tag --list 'v[0-9]*')
           if [[ -z "$all_release_tags" ]]; then

--- a/.github/workflows/release-backend-app-generic.yml
+++ b/.github/workflows/release-backend-app-generic.yml
@@ -129,15 +129,17 @@ jobs:
       # There are no good workarounds to checkout a companion file (script or composite action)
       - name: Check if gitReference is missing already released commits
         run: |
-          # This ensures that we don't silently drop commits (such as security fixes) by
-          # rereleasing as new version an old commit that was already released. Another
-          # possibility is to use a non linear history and branch from an old commit
-          # and merge to the tip of main, but then release the new branched commit (which
-          # was not already rereleased, but which also doesn't contain the recent commits)
+          # The following block ensures that the new release will not omit
+          # commits that were already released. If this case was allowed, then
+          # it would for instance be possible to release a new version without
+          # some security fixes. For linear histories, this would happen when
+          # rereleasing an old commit as a new version. For non linear histories,
+          # this could additionally happen when releasing a new commit (subsequently
+          # merged in main) but that branches off of old commits (or even unrelated histories).
           # If the code that finds existing releases fails and doesn't find anything, it
           # could be the first release, or it could be that there is a bug or exploit. In
           # this case, instead of allowing to release anything, we just allow to release the
-          # tip of main (allowing to release anything else would allow to drop commits).
+          # tip of main (allowing to release anything else would also allow to omit commits).
           # NOTE: needs fetch-depth: 0
           all_release_tags=$(git tag --list 'v[0-9]*')
           if [[ -z "$all_release_tags" ]]; then

--- a/.github/workflows/release-base-docker-image-generic.yml
+++ b/.github/workflows/release-base-docker-image-generic.yml
@@ -116,19 +116,21 @@ jobs:
       # There are no good workarounds to checkout a companion file (script or composite action)
       - name: Check if gitReference is missing already released commits
         run: |
-          # This ensures that we don't silently drop commits (such as security fixes) by
-          # rereleasing as new version an old commit that was already released. Another
-          # possibility is to use a non linear history and branch from an old commit
-          # and merge to the tip of main, but then release the new branched commit (which
-          # was not already rereleased, but which also doesn't contain the recent commits)
+          # The following block ensures that the new release will not omit
+          # commits that were already released. If this case was allowed, then
+          # it would for instance be possible to release a new version without
+          # some security fixes. For linear histories, this would happen when
+          # rereleasing an old commit as a new version. For non linear histories,
+          # this could additionally happen when releasing a new commit (subsequently
+          # merged in main) but that branches off of old commits (or even unrelated histories).
           # If the code that finds existing releases fails and doesn't find anything, it
           # could be the first release, or it could be that there is a bug or exploit. In
           # this case, instead of allowing to release anything, we just allow to release the
-          # tip of main (allowing to release anything would allow to drop commits).
+          # tip of main (allowing to release anything else would also allow to omit commits).
           # NOTE: needs fetch-depth: 0
           all_release_tags=$(git tag --list 'v[0-9]*')
           if [[ -z "$all_release_tags" ]]; then
-            echo "WARN no existing release tags found, is this the first release ?"
+            echo "WARN no existing release tags found, is this the first release?"
             if ! git_reference_parsed=$(git rev-parse "$RUNGHA_GIT_REFERENCE"); then
               echo "ERROR rev-parsing gitRef $RUNGHA_GIT_REFERENCE"
               exit 1

--- a/.github/workflows/release-base-docker-image-generic.yml
+++ b/.github/workflows/release-base-docker-image-generic.yml
@@ -114,21 +114,43 @@ jobs:
       # TODO deduplicate this code when github actions allows to easily share a script used
       # by reusable workflows. Currently only the workflow file is checked out at the caller
       # There are no good workarounds to checkout a companion file (script or composite action)
-      - name: Check if gitReference is already released
+      - name: Check if gitReference is missing already released commits
         run: |
-          # needs fetch-depth: 0
-          # This ensures that an old commit (potentially with a security issue) can not be rereleased
-          # as a new version (thus potentially restoring a security issue). This will not block regular
-          # releases because there is always at least the version bump commit in a real new release even if
-          # we are just rereleasing the same code with a new name as part of a global release.
-          if ! release_tags=$(git tag --contains "$RUNGHA_GIT_REFERENCE" 'v[0-9]*'); then
-            echo "ERROR checking whether gitRef $RUNGHA_GIT_REFERENCE is already released or not."
-            exit 1
-          elif [ -n "$release_tags" ]; then
-            echo "ERROR: gitRef $RUNGHA_GIT_REFERENCE already released: $release_tags"
-            exit 1
+          # This ensures that we don't silently drop commits (such as security fixes) by
+          # rereleasing as new version an old commit that was already released. Another
+          # possibility is to use a non linear history and branch from an old commit
+          # and merge to the tip of main, but then release the new branched commit (which
+          # was not already rereleased, but which also doesn't contain the recent commits)
+          # If the code that finds existing releases fails and doesn't find anything, it
+          # could be the first release, or it could be that there is a bug or exploit. In
+          # this case, instead of allowing to release anything, we just allow to release the
+          # tip of main (allowing to release anything would allow to drop commits).
+          # NOTE: needs fetch-depth: 0
+          all_release_tags=$(git tag --list 'v[0-9]*')
+          if [[ -z "$all_release_tags" ]]; then
+            echo "WARN no existing release tags found, is this the first release ?"
+            if ! git_reference_parsed=$(git rev-parse "$RUNGHA_GIT_REFERENCE"); then
+              echo "ERROR rev-parsing gitRef $RUNGHA_GIT_REFERENCE"
+              exit 1
+            fi
+            if ! main_parsed=$(git rev-parse origin/main); then
+              echo "ERROR rev-parsing origin/main"
+              exit 1
+            fi
+            if [[ -n "$git_reference_parsed" && "$git_reference_parsed" != "$main_parsed" ]]; then
+              echo "ERROR: No existing release found, must release the tip of main $main_parsed but got $git_reference_parsed"
+              exit 1
+            else
+              echo "gitRef $RUNGHA_GIT_REFERENCE is tip of main, release will be performed"
+            fi
           else
-            echo "gitRef $RUNGHA_GIT_REFERENCE never released, release will be performed"
+            latest_main_release=$(git merge-base main $all_release_tags)
+            if ! git merge-base --is-ancestor "$latest_main_release" "$RUNGHA_GIT_REFERENCE"; then
+              echo "ERROR gitRef $RUNGHA_GIT_REFERENCE is not a descendant of the latest released commit $latest_main_release"
+              exit 1
+            else
+              echo "gitRef $RUNGHA_GIT_REFERENCE descends from previous releases, release will be performed"
+            fi
           fi
         env:
           RUNGHA_GIT_REFERENCE: ${{ inputs.gitReference }} # just for defense against script injection

--- a/.github/workflows/release-frontend-app-generic.yml
+++ b/.github/workflows/release-frontend-app-generic.yml
@@ -119,21 +119,43 @@ jobs:
       # TODO deduplicate this code when github actions allows to easily share a script used
       # by reusable workflows. Currently only the workflow file is checked out at the caller
       # There are no good workarounds to checkout a companion file (script or composite action)
-      - name: Check if commitSha is already released
+      - name: Check if commitSha is missing already released commits
         run: |
-          # needs fetch-depth: 0
-          # This ensures that an old commit (potentially with a security issue) can not be rereleased
-          # as a new version (thus potentially restoring a security issue). This will not block regular
-          # releases because there is always at least the version bump commit in a real new release even if
-          # we are just rereleasing the same code with a new name as part of a global release.
-          if ! release_tags=$(git tag --contains "$RUNGHA_COMMIT_SHA" 'v[0-9]*'); then
-            echo "ERROR checking whether sha $RUNGHA_COMMIT_SHA is already released or not."
-            exit 1
-          elif [ -n "$release_tags" ]; then
-            echo "ERROR: sha $RUNGHA_COMMIT_SHA already released: $release_tags"
-            exit 1
+          # This ensures that we don't silently drop commits (such as security fixes) by
+          # rereleasing as new version an old commit that was already released. Another
+          # possibility is to use a non linear history and branch from an old commit
+          # and merge to the tip of main, but then release the new branched commit (which
+          # was not already rereleased, but which also doesn't contain the recent commits)
+          # If the code that finds existing releases fails and doesn't find anything, it
+          # could be the first release, or it could be that there is a bug or exploit. In
+          # this case, instead of allowing to release anything, we just allow to release the
+          # tip of main (allowing to release anything would allow to drop commits).
+          # NOTE: needs fetch-depth: 0
+          all_release_tags=$(git tag --list 'v[0-9]*')
+          if [[ -z "$all_release_tags" ]]; then
+            echo "WARN no existing release tags found, is this the first release ?"
+            if ! git_reference_parsed=$(git rev-parse "$RUNGHA_COMMIT_SHA"); then
+              echo "ERROR rev-parsing gitRef $RUNGHA_COMMIT_SHA"
+              exit 1
+            fi
+            if ! main_parsed=$(git rev-parse origin/main); then
+              echo "ERROR rev-parsing origin/main"
+              exit 1
+            fi
+            if [[ -n "$git_reference_parsed" && "$git_reference_parsed" != "$main_parsed" ]]; then
+              echo "ERROR: No existing release found, must release the tip of main $main_parsed but got $git_reference_parsed"
+              exit 1
+            else
+              echo "gitRef $RUNGHA_COMMIT_SHA is tip of main, release will be performed"
+            fi
           else
-            echo "sha $RUNGHA_COMMIT_SHA never released, release will be performed"
+            latest_main_release=$(git merge-base main $all_release_tags)
+            if ! git merge-base --is-ancestor "$latest_main_release" "$RUNGHA_COMMIT_SHA"; then
+              echo "ERROR gitRef $RUNGHA_COMMIT_SHA is not a descendant of the latest released commit $latest_main_release"
+              exit 1
+            else
+              echo "gitRef $RUNGHA_COMMIT_SHA descends from previous releases, release will be performed"
+            fi
           fi
         env:
           RUNGHA_COMMIT_SHA: ${{ inputs.commitSha }} # just for defense against script injection

--- a/.github/workflows/release-frontend-app-generic.yml
+++ b/.github/workflows/release-frontend-app-generic.yml
@@ -121,19 +121,21 @@ jobs:
       # There are no good workarounds to checkout a companion file (script or composite action)
       - name: Check if commitSha is missing already released commits
         run: |
-          # This ensures that we don't silently drop commits (such as security fixes) by
-          # rereleasing as new version an old commit that was already released. Another
-          # possibility is to use a non linear history and branch from an old commit
-          # and merge to the tip of main, but then release the new branched commit (which
-          # was not already rereleased, but which also doesn't contain the recent commits)
+          # The following block ensures that the new release will not omit
+          # commits that were already released. If this case was allowed, then
+          # it would for instance be possible to release a new version without
+          # some security fixes. For linear histories, this would happen when
+          # rereleasing an old commit as a new version. For non linear histories,
+          # this could additionally happen when releasing a new commit (subsequently
+          # merged in main) but that branches off of old commits (or even unrelated histories).
           # If the code that finds existing releases fails and doesn't find anything, it
           # could be the first release, or it could be that there is a bug or exploit. In
           # this case, instead of allowing to release anything, we just allow to release the
-          # tip of main (allowing to release anything would allow to drop commits).
+          # tip of main (allowing to release anything else would also allow to omit commits).
           # NOTE: needs fetch-depth: 0
           all_release_tags=$(git tag --list 'v[0-9]*')
           if [[ -z "$all_release_tags" ]]; then
-            echo "WARN no existing release tags found, is this the first release ?"
+            echo "WARN no existing release tags found, is this the first release?"
             if ! git_reference_parsed=$(git rev-parse "$RUNGHA_COMMIT_SHA"); then
               echo "ERROR rev-parsing gitRef $RUNGHA_COMMIT_SHA"
               exit 1

--- a/.github/workflows/release-sources-generic.yml
+++ b/.github/workflows/release-sources-generic.yml
@@ -106,21 +106,43 @@ jobs:
       # TODO deduplicate this code when github actions allows to easily share a script used
       # by reusable workflows. Currently only the workflow file is checked out at the caller
       # There are no good workarounds to checkout a companion file (script or composite action)
-      - name: Check if gitReference is already released
+      - name: Check if gitReference is missing already released commits
         run: |
-          # needs fetch-depth: 0
-          # This ensures that an old commit (potentially with a security issue) can not be rereleased
-          # as a new version (thus potentially restoring a security issue). This will not block regular
-          # releases because there is always at least the version bump commit in a real new release even if
-          # we are just rereleasing the same code with a new name as part of a global release.
-          if ! release_tags=$(git tag --contains "$RUNGHA_GIT_REFERENCE" 'v[0-9]*'); then
-            echo "ERROR checking whether gitRef $RUNGHA_GIT_REFERENCE is already released or not."
-            exit 1
-          elif [ -n "$release_tags" ]; then
-            echo "ERROR: gitRef $RUNGHA_GIT_REFERENCE already released: $release_tags"
-            exit 1
+          # This ensures that we don't silently drop commits (such as security fixes) by
+          # rereleasing as new version an old commit that was already released. Another
+          # possibility is to use a non linear history and branch from an old commit
+          # and merge to the tip of main, but then release the new branched commit (which
+          # was not already rereleased, but which also doesn't contain the recent commits)
+          # If the code that finds existing releases fails and doesn't find anything, it
+          # could be the first release, or it could be that there is a bug or exploit. In
+          # this case, instead of allowing to release anything, we just allow to release the
+          # tip of main (allowing to release anything would allow to drop commits).
+          # NOTE: needs fetch-depth: 0
+          all_release_tags=$(git tag --list 'v[0-9]*')
+          if [[ -z "$all_release_tags" ]]; then
+            echo "WARN no existing release tags found, is this the first release ?"
+            if ! git_reference_parsed=$(git rev-parse "$RUNGHA_GIT_REFERENCE"); then
+              echo "ERROR rev-parsing gitRef $RUNGHA_GIT_REFERENCE"
+              exit 1
+            fi
+            if ! main_parsed=$(git rev-parse origin/main); then
+              echo "ERROR rev-parsing origin/main"
+              exit 1
+            fi
+            if [[ -n "$git_reference_parsed" && "$git_reference_parsed" != "$main_parsed" ]]; then
+              echo "ERROR: No existing release found, must release the tip of main $main_parsed but got $git_reference_parsed"
+              exit 1
+            else
+              echo "gitRef $RUNGHA_GIT_REFERENCE is tip of main, release will be performed"
+            fi
           else
-            echo "gitRef $RUNGHA_GIT_REFERENCE never released, release will be performed"
+            latest_main_release=$(git merge-base main $all_release_tags)
+            if ! git merge-base --is-ancestor "$latest_main_release" "$RUNGHA_GIT_REFERENCE"; then
+              echo "ERROR gitRef $RUNGHA_GIT_REFERENCE is not a descendant of the latest released commit $latest_main_release"
+              exit 1
+            else
+              echo "gitRef $RUNGHA_GIT_REFERENCE descends from previous releases, release will be performed"
+            fi
           fi
         env:
           RUNGHA_GIT_REFERENCE: ${{ inputs.gitReference }} # just for defense against script injection

--- a/.github/workflows/release-sources-generic.yml
+++ b/.github/workflows/release-sources-generic.yml
@@ -108,19 +108,21 @@ jobs:
       # There are no good workarounds to checkout a companion file (script or composite action)
       - name: Check if gitReference is missing already released commits
         run: |
-          # This ensures that we don't silently drop commits (such as security fixes) by
-          # rereleasing as new version an old commit that was already released. Another
-          # possibility is to use a non linear history and branch from an old commit
-          # and merge to the tip of main, but then release the new branched commit (which
-          # was not already rereleased, but which also doesn't contain the recent commits)
+          # The following block ensures that the new release will not omit
+          # commits that were already released. If this case was allowed, then
+          # it would for instance be possible to release a new version without
+          # some security fixes. For linear histories, this would happen when
+          # rereleasing an old commit as a new version. For non linear histories,
+          # this could additionally happen when releasing a new commit (subsequently
+          # merged in main) but that branches off of old commits (or even unrelated histories).
           # If the code that finds existing releases fails and doesn't find anything, it
           # could be the first release, or it could be that there is a bug or exploit. In
           # this case, instead of allowing to release anything, we just allow to release the
-          # tip of main (allowing to release anything would allow to drop commits).
+          # tip of main (allowing to release anything else would also allow to omit commits).
           # NOTE: needs fetch-depth: 0
           all_release_tags=$(git tag --list 'v[0-9]*')
           if [[ -z "$all_release_tags" ]]; then
-            echo "WARN no existing release tags found, is this the first release ?"
+            echo "WARN no existing release tags found, is this the first release?"
             if ! git_reference_parsed=$(git rev-parse "$RUNGHA_GIT_REFERENCE"); then
               echo "ERROR rev-parsing gitRef $RUNGHA_GIT_REFERENCE"
               exit 1


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
feature/bugfix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
can't rerelease tip
can release old commit when non linear histories are allowed


**What is the new behavior (if this is a feature change)?**
can release tip
can't release old commit


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Compared to the previous strategy of allowing only unreleased commits:
- This strategy has the advantage of allowing to rerelease the latest released commit.
- For repos which allow non linear histories on main, this fixes the problem that a new commit branched from and old commit is actually unreleased so could be released but would drop important commits.

