### PR TITLE
releases: run git clean before switching to main for the version bump commit

### DIFF
--- a/.github/workflows/release-backend-app-generic.yml
+++ b/.github/workflows/release-backend-app-generic.yml
@@ -261,6 +261,7 @@ jobs:
 
       - name: Checkout main
         run: |
+          git clean -f -d
           git checkout main
           git pull
 

--- a/.github/workflows/release-frontend-app-generic.yml
+++ b/.github/workflows/release-frontend-app-generic.yml
@@ -262,6 +262,7 @@ jobs:
 
       - name: Checkout main
         run: |
+          git clean -f -d
           git checkout main
           git pull
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
bugfix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
release can commit bad files to main (build files)


**What is the new behavior (if this is a feature change)?**
clean main checkout


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**Other information**:
This removes build artifact from the branch (e.g. sonar reports) that could be committed in the versionbump commit by mistake if the .gitignore is not correctly setup and we add everything

Anecdotally, this allows prevents conflicts when switching which would fail the release although the build should never modify tracked files.

