### PR TITLE
remove useless env copy for script injection protection for values already in the env

### DIFF
--- a/.github/workflows/patch-backend-app-generic.yml
+++ b/.github/workflows/patch-backend-app-generic.yml
@@ -149,9 +149,7 @@ jobs:
           fi
 
       - name: Change Maven version to release version
-        run: mvn --batch-mode versions:set -DgenerateBackupPoms=false -DnewVersion="$RUNGHA_GITHUB_SHORT_VERSION"
-        env:
-          RUNGHA_GITHUB_SHORT_VERSION: ${{ env.GITHUB_SHORT_VERSION }} # just for defense against script injection
+        run: mvn --batch-mode versions:set -DgenerateBackupPoms=false -DnewVersion="$GITHUB_SHORT_VERSION"
 
       # creates a signed commit on the tmp remote branch with our diff, and
       # then updates (fast-forward) our local branch to this new commit. It
@@ -167,11 +165,8 @@ jobs:
 
       - name: Create local tag and cleanup remote tmp branch
         run: |
-          git push origin ":${RUNGHA_TMPRELEASEBRANCH}"
-          git tag "v$RUNGHA_GITHUB_SHORT_VERSION"
-        env:
-          RUNGHA_TMPRELEASEBRANCH: ${{ env.TMPRELEASEBRANCH }} # just for defense against script injection
-          RUNGHA_GITHUB_SHORT_VERSION: ${{ env.GITHUB_SHORT_VERSION }} # just for defense against script injection
+          git push origin ":${TMPRELEASEBRANCH}"
+          git tag "v$GITHUB_SHORT_VERSION"
 
       - name: Build with Maven
         run: >
@@ -187,20 +182,15 @@ jobs:
         run: >
           mvn --batch-mode deploy -DskipTests -Dmaven.install.skip -Dmaven.deploy.skip -Dpowsybl.docker.deploy
           -Djib.httpTimeout=60000
-          -Djib.to.image="$RUNGHA_DOCKER_IMAGE:$RUNGHA_GITHUB_SHORT_VERSION"
+          -Djib.to.image="$RUNGHA_DOCKER_IMAGE:$GITHUB_SHORT_VERSION"
           -Djib.to.auth.username="$RUNGHA_DOCKER_USERNAME"
           -Djib.to.auth.password="$RUNGHA_DOCKERHUB_TOKEN"
         env:
           RUNGHA_DOCKER_IMAGE: ${{ inputs.dockerImage }} # just for defense against script injection
           RUNGHA_DOCKER_USERNAME: ${{ inputs.dockerUsername }} # just for defense against script injection
           RUNGHA_DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }} # just for defense against script injection
-          RUNGHA_GITHUB_SHORT_VERSION: ${{ env.GITHUB_SHORT_VERSION }} # just for defense against script injection
 
       - name: Push release branch and tag
         run: |
-          git push origin "release-v${RUNGHA_GITHUB_MAJOR_VERSION}.${RUNGHA_GITHUB_MINOR_VERSION}"
-          git push origin "v$RUNGHA_GITHUB_SHORT_VERSION"
-        env:
-          RUNGHA_GITHUB_MAJOR_VERSION: ${{ env.GITHUB_MAJOR_VERSION }} # just for defense against script injection
-          RUNGHA_GITHUB_MINOR_VERSION: ${{ env.GITHUB_MINOR_VERSION }} # just for defense against script injection
-          RUNGHA_GITHUB_SHORT_VERSION: ${{ env.GITHUB_SHORT_VERSION }} # just for defense against script injection
+          git push origin "release-v${GITHUB_MAJOR_VERSION}.${GITHUB_MINOR_VERSION}"
+          git push origin "v$GITHUB_SHORT_VERSION"

--- a/.github/workflows/patch-backend-lib-generic.yml
+++ b/.github/workflows/patch-backend-lib-generic.yml
@@ -136,14 +136,13 @@ jobs:
 
       - name: Create and push tag and cleanup remote tmp branch
         run: |
-          git push origin ":$RUNGHA_TMPRELEASEBRANCH"
+          git push origin ":$TMPRELEASEBRANCH"
           git tag "v$RUNGHA_PATCH_VERSION"
           git push origin "v$RUNGHA_PATCH_VERSION"
           git push origin "$RUNGHA_BRANCH_REF"
         env:
           RUNGHA_PATCH_VERSION: ${{ steps.versions.outputs.PATCH_VERSION }} # just for defense against script injection
           RUNGHA_BRANCH_REF: ${{ inputs.branchRef }} # just for defense against script injection
-          RUNGHA_TMPRELEASEBRANCH: ${{ env.TMPRELEASEBRANCH }} # just for defense against script injection
 
       - name: Create GitHub Release
         env:

--- a/.github/workflows/patch-base-docker-image-generic.yml
+++ b/.github/workflows/patch-base-docker-image-generic.yml
@@ -133,9 +133,7 @@ jobs:
 
       - name: Create tag
         run: |
-          git tag "v$RUNGHA_GITHUB_SHORT_VERSION"
-        env:
-          RUNGHA_GITHUB_SHORT_VERSION: ${{ env.GITHUB_SHORT_VERSION }} # just for defense against script injection
+          git tag "v$GITHUB_SHORT_VERSION"
 
       - name: Build and publish Docker image
         uses: elgohr/Publish-Docker-Github-Action@33a481be3e179353cb7793a92b57cf9a6c985860 # v4
@@ -147,6 +145,4 @@ jobs:
 
       - name: Push release branch and tag
         run: |
-          git push origin "v$RUNGHA_GITHUB_SHORT_VERSION"
-        env:
-          RUNGHA_GITHUB_SHORT_VERSION: ${{ env.GITHUB_SHORT_VERSION }} # just for defense against script injection
+          git push origin "v$GITHUB_SHORT_VERSION"

--- a/.github/workflows/patch-frontend-app-generic.yml
+++ b/.github/workflows/patch-frontend-app-generic.yml
@@ -156,9 +156,7 @@ jobs:
       - name: Create New Version
         run: |
           # Use npm version to update version, don't create commit and tag
-          npm version --no-git-tag-version "$RUNGHA_ENV_RELEASE_VERSION"
-        env:
-          RUNGHA_ENV_RELEASE_VERSION: ${{ env.RELEASE_VERSION }} # just for defense against script injection
+          npm version --no-git-tag-version "$RELEASE_VERSION"
 
       # creates a signed commit on the tmp remote branch with our diff, and
       # then updates (fast-forward) our local branch to this new commit. It
@@ -174,11 +172,8 @@ jobs:
 
       - name: Create local tag and cleanup remote tmp branch
         run: |
-          git push origin ":$RUNGHA_TMPRELEASEBRANCH"
-          git tag "v$RUNGHA_ENV_RELEASE_VERSION"
-        env:
-          RUNGHA_TMPRELEASEBRANCH: ${{ env.TMPRELEASEBRANCH }} # just for defense against script injection
-          RUNGHA_ENV_RELEASE_VERSION: ${{ env.RELEASE_VERSION }} # just for defense against script injection
+          git push origin ":$TMPRELEASEBRANCH"
+          git tag "v$RELEASE_VERSION"
 
       - name: Install Dependencies
         run: npm ci
@@ -207,8 +202,7 @@ jobs:
 
       - name: Push tag and release branch
         run: |
-          git push origin "v$RUNGHA_ENV_RELEASE_VERSION"
+          git push origin "v$RELEASE_VERSION"
           git push origin "release-$RUNGHA_INPUT_RELEASE_VERSION"
         env:
           RUNGHA_INPUT_RELEASE_VERSION: ${{ inputs.releaseVersion }} # just for defense against script injection
-          RUNGHA_ENV_RELEASE_VERSION: ${{ env.RELEASE_VERSION }} # just for defense against script injection

--- a/.github/workflows/patch-sources-generic.yml
+++ b/.github/workflows/patch-sources-generic.yml
@@ -125,12 +125,8 @@ jobs:
 
       - name: Create tag
         run: |
-          git tag "v$RUNGHA_GITHUB_SHORT_VERSION"
-        env:
-          RUNGHA_GITHUB_SHORT_VERSION: ${{ env.GITHUB_SHORT_VERSION }} # just for defense against script injection
+          git tag "v$GITHUB_SHORT_VERSION"
 
       - name: Push release branch and tag
         run: |
-          git push origin "v$RUNGHA_GITHUB_SHORT_VERSION"
-        env:
-          RUNGHA_GITHUB_SHORT_VERSION: ${{ env.GITHUB_SHORT_VERSION }} # just for defense against script injection
+          git push origin "v$GITHUB_SHORT_VERSION"

--- a/.github/workflows/release-backend-app-generic.yml
+++ b/.github/workflows/release-backend-app-generic.yml
@@ -189,23 +189,19 @@ jobs:
 
       - name: Checkout with new branch, push tmp branch for signed commit
         run: |
-          git checkout -b "release-v${RUNGHA_GITHUB_MAJOR_VERSION}.${RUNGHA_GITHUB_MINOR_VERSION}" "$RUNGHA_GIT_REFERENCE"
+          git checkout -b "release-v${GITHUB_MAJOR_VERSION}.${GITHUB_MINOR_VERSION}" "$RUNGHA_GIT_REFERENCE"
           TMPRANDOM="$(printf "%04x" $RANDOM)$(printf "%04x" $RANDOM)$(printf "%04x" $RANDOM)"
           # random prefix so that it's not protected, but keep release information to give context
           # can't be protected because the github commit API doesn't allow to create a commit on
           # protected branch even though we have bypass rights for the token of the app
-          TMPRELEASEBRANCH="copy-${TMPRANDOM}-release-v${RUNGHA_GITHUB_MAJOR_VERSION}.${RUNGHA_GITHUB_MINOR_VERSION}"
-          git push origin "release-v${RUNGHA_GITHUB_MAJOR_VERSION}.${RUNGHA_GITHUB_MINOR_VERSION}:$TMPRELEASEBRANCH"
+          TMPRELEASEBRANCH="copy-${TMPRANDOM}-release-v${GITHUB_MAJOR_VERSION}.${GITHUB_MINOR_VERSION}"
+          git push origin "release-v${GITHUB_MAJOR_VERSION}.${GITHUB_MINOR_VERSION}:$TMPRELEASEBRANCH"
           echo "TMPRELEASEBRANCH=$TMPRELEASEBRANCH" >> $GITHUB_ENV
         env:
-          RUNGHA_GITHUB_MAJOR_VERSION: ${{ env.GITHUB_MAJOR_VERSION }} # just for defense against script injection
-          RUNGHA_GITHUB_MINOR_VERSION: ${{ env.GITHUB_MINOR_VERSION }} # just for defense against script injection
           RUNGHA_GIT_REFERENCE: ${{ inputs.gitReference }} # just for defense against script injection
 
       - name: Change Maven version to release version
-        run: mvn --batch-mode versions:set -DgenerateBackupPoms=false -DnewVersion="$RUNGHA_GITHUB_SHORT_VERSION"
-        env:
-          RUNGHA_GITHUB_SHORT_VERSION: ${{ env.GITHUB_SHORT_VERSION }} # just for defense against script injection
+        run: mvn --batch-mode versions:set -DgenerateBackupPoms=false -DnewVersion="$GITHUB_SHORT_VERSION"
 
       # creates a signed commit on the tmp remote branch with our diff, and
       # then updates (fast-forward) our local branch to this new commit. It
@@ -221,11 +217,8 @@ jobs:
 
       - name: Create local tag and cleanup remote tmp branch
         run: |
-          git push origin ":${RUNGHA_TMPRELEASEBRANCH}"
-          git tag "v$RUNGHA_GITHUB_SHORT_VERSION"
-        env:
-          RUNGHA_GITHUB_SHORT_VERSION: ${{ env.GITHUB_SHORT_VERSION }} # just for defense against script injection
-          RUNGHA_TMPRELEASEBRANCH: ${{ env.TMPRELEASEBRANCH }} # just for defense against script injection
+          git push origin ":${TMPRELEASEBRANCH}"
+          git tag "v$GITHUB_SHORT_VERSION"
 
       - name: Build with Maven
         run: >
@@ -241,23 +234,18 @@ jobs:
         run: >
           mvn --batch-mode deploy -DskipTests -Dmaven.install.skip -Dmaven.deploy.skip -Dpowsybl.docker.deploy
           -Djib.httpTimeout=60000
-          -Djib.to.image="$RUNGHA_DOCKER_IMAGE:$RUNGHA_GITHUB_SHORT_VERSION"
+          -Djib.to.image="$RUNGHA_DOCKER_IMAGE:$GITHUB_SHORT_VERSION"
           -Djib.to.auth.username="$RUNGHA_DOCKER_USERNAME"
           -Djib.to.auth.password="$RUNGHA_DOCKERHUB_TOKEN"
         env:
           RUNGHA_DOCKER_IMAGE: ${{ inputs.dockerImage }} # just for defense against script injection
           RUNGHA_DOCKER_USERNAME: ${{ inputs.dockerUsername }} # just for defense against script injection
           RUNGHA_DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }} # just for defense against script injection
-          RUNGHA_GITHUB_SHORT_VERSION: ${{ env.GITHUB_SHORT_VERSION }} # just for defense against script injection
 
       - name: Push release branch and tag
         run: |
-          git push origin "release-v${RUNGHA_GITHUB_MAJOR_VERSION}.${RUNGHA_GITHUB_MINOR_VERSION}"
-          git push origin "v$RUNGHA_GITHUB_SHORT_VERSION"
-        env:
-          RUNGHA_GITHUB_MAJOR_VERSION: ${{ env.GITHUB_MAJOR_VERSION }} # just for defense against script injection
-          RUNGHA_GITHUB_MINOR_VERSION: ${{ env.GITHUB_MINOR_VERSION }} # just for defense against script injection
-          RUNGHA_GITHUB_SHORT_VERSION: ${{ env.GITHUB_SHORT_VERSION }} # just for defense against script injection
+          git push origin "release-v${GITHUB_MAJOR_VERSION}.${GITHUB_MINOR_VERSION}"
+          git push origin "v$GITHUB_SHORT_VERSION"
 
       - name: Checkout main
         run: |
@@ -272,12 +260,10 @@ jobs:
       - name: Extract current version
         run: |
           regex="(.*)-SNAPSHOT"
-          if [[ $RUNGHA_CURRENT_MAVEN_VERSION =~ $regex ]]
+          if [[ $CURRENT_MAVEN_VERSION =~ $regex ]]
           then
             echo "CURRENT_RELEASE_VERSION=${BASH_REMATCH[1]}" >> $GITHUB_ENV
           fi
-        env:
-          RUNGHA_CURRENT_MAVEN_VERSION: ${{ env.CURRENT_MAVEN_VERSION }} # just for defense against script injection
 
       - name: Prepare Update SNAPSHOT version on main (tmp branch for signed commit)
         if: env.CURRENT_RELEASE_VERSION == env.GITHUB_SHORT_VERSION
@@ -286,24 +272,17 @@ jobs:
           # random prefix so that it's not protected, but keep release information to give context
           # can't be protected because the github commit API doesn't allow to create a commit on
           # protected branch even though we have bypass rights for the token of the app
-          TMPMAINBRANCH="copy-${TMPRANDOM}-main-v${RUNGHA_GITHUB_MAJOR_VERSION}.${RUNGHA_GITHUB_MINOR_VERSION}"
+          TMPMAINBRANCH="copy-${TMPRANDOM}-main-v${GITHUB_MAJOR_VERSION}.${GITHUB_MINOR_VERSION}"
           git push origin "main:$TMPMAINBRANCH"
           echo "TMPMAINBRANCH=$TMPMAINBRANCH" >> $GITHUB_ENV
-        env:
-          RUNGHA_GITHUB_MAJOR_VERSION: ${{ env.GITHUB_MAJOR_VERSION }} # just for defense against script injection
-          RUNGHA_GITHUB_MINOR_VERSION: ${{ env.GITHUB_MINOR_VERSION }} # just for defense against script injection
 
       - name: Update SNAPSHOT version on main
         if: env.CURRENT_RELEASE_VERSION == env.GITHUB_SHORT_VERSION
         run: |
-          minor=$RUNGHA_GITHUB_MINOR_VERSION
+          minor=$GITHUB_MINOR_VERSION 
           ((++minor))
-          mvn --batch-mode versions:set -DgenerateBackupPoms=false -DnewVersion=$RUNGHA_GITHUB_MAJOR_VERSION.$minor.0-SNAPSHOT
+          mvn --batch-mode versions:set -DgenerateBackupPoms=false -DnewVersion=$GITHUB_MAJOR_VERSION .$minor.0-SNAPSHOT
           echo "MAIN_MINOR=$minor" >> $GITHUB_ENV
-
-        env:
-          RUNGHA_GITHUB_MAJOR_VERSION: ${{ env.GITHUB_MAJOR_VERSION }} # just for defense against script injection
-          RUNGHA_GITHUB_MINOR_VERSION: ${{ env.GITHUB_MINOR_VERSION }} # just for defense against script injection
 
       # creates a signed commit on the tmp remote branch with our diff, and
       # then updates (fast-forward) our local branch to this new commit. It
@@ -321,7 +300,5 @@ jobs:
       - name: push to main and cleanup remote tmp branch
         if: env.CURRENT_RELEASE_VERSION == env.GITHUB_SHORT_VERSION
         run: |
-          git push origin ":${RUNGHA_TMPMAINBRANCH}"
+          git push origin ":${TMPMAINBRANCH}"
           git push
-        env:
-          RUNGHA_TMPMAINBRANCH: ${{ env.TMPMAINBRANCH }} # just for defense against script injection

--- a/.github/workflows/release-backend-lib-generic.yml
+++ b/.github/workflows/release-backend-lib-generic.yml
@@ -183,7 +183,5 @@ jobs:
 
       - name: push to main and cleanup remote tmp branch
         run: |
-          git push origin ":${RUNGHA_TMPMAINBRANCH}"
+          git push origin ":${TMPMAINBRANCH}"
           git push origin main
-        env:
-          RUNGHA_TMPMAINBRANCH: ${{ env.TMPMAINBRANCH }} # just for defense against script injection

--- a/.github/workflows/release-base-docker-image-generic.yml
+++ b/.github/workflows/release-base-docker-image-generic.yml
@@ -179,17 +179,13 @@ jobs:
 
       - name: Checkout with new branch
         run: |
-          git checkout -b "release-v${RUNGHA_GITHUB_MAJOR_VERSION}.${RUNGHA_GITHUB_MINOR_VERSION}" "$RUNGHA_GIT_REFERENCE"
+          git checkout -b "release-v${GITHUB_MAJOR_VERSION}.${GITHUB_MINOR_VERSION}" "$RUNGHA_GIT_REFERENCE"
         env:
-          RUNGHA_GITHUB_MAJOR_VERSION: ${{ env.GITHUB_MAJOR_VERSION }} # just for defense against script injection
-          RUNGHA_GITHUB_MINOR_VERSION: ${{ env.GITHUB_MINOR_VERSION }} # just for defense against script injection
           RUNGHA_GIT_REFERENCE: ${{ inputs.gitReference }} # just for defense against script injection
 
       - name: Create tag
         run: |
-          git tag "v$RUNGHA_GITHUB_SHORT_VERSION"
-        env:
-          RUNGHA_GITHUB_SHORT_VERSION: ${{ env.GITHUB_SHORT_VERSION }} # just for defense against script injection
+          git tag "v$GITHUB_SHORT_VERSION"
 
       - name: Build and publish Docker image
         uses: elgohr/Publish-Docker-Github-Action@33a481be3e179353cb7793a92b57cf9a6c985860 # v4
@@ -201,9 +197,5 @@ jobs:
 
       - name: Push release branch and tag
         run: |
-          git push origin "release-v${RUNGHA_GITHUB_MAJOR_VERSION}.${RUNGHA_GITHUB_MINOR_VERSION}"
-          git push origin "v$RUNGHA_GITHUB_SHORT_VERSION"
-        env:
-          RUNGHA_GITHUB_MAJOR_VERSION: ${{ env.GITHUB_MAJOR_VERSION }} # just for defense against script injection
-          RUNGHA_GITHUB_MINOR_VERSION: ${{ env.GITHUB_MINOR_VERSION }} # just for defense against script injection
-          RUNGHA_GITHUB_SHORT_VERSION: ${{ env.GITHUB_SHORT_VERSION }} # just for defense against script injection
+          git push origin "release-v${GITHUB_MAJOR_VERSION}.${GITHUB_MINOR_VERSION}"
+          git push origin "v$GITHUB_SHORT_VERSION"

--- a/.github/workflows/release-frontend-app-generic.yml
+++ b/.github/workflows/release-frontend-app-generic.yml
@@ -187,25 +187,22 @@ jobs:
 
       - name: Create Release Branch, push tmp branch for signed commit
         run: |
-          git checkout -b "$RUNGHA_RELEASE_BRANCH" "$RUNGHA_COMMIT_SHA"
+          git checkout -b "$RELEASE_BRANCH" "$RUNGHA_COMMIT_SHA"
 
           TMPRANDOM="$(printf "%04x" $RANDOM)$(printf "%04x" $RANDOM)$(printf "%04x" $RANDOM)"
           # random prefix so that it's not protected, but keep release information to give context
           # can't be protected because the github commit API doesn't allow to create a commit on
           # protected branch even though we have bypass rights for the token of the app
-          TMPRELEASEBRANCH="copy-${TMPRANDOM}-${RUNGHA_RELEASE_BRANCH}"
-          git push origin "$RUNGHA_RELEASE_BRANCH:$TMPRELEASEBRANCH"
+          TMPRELEASEBRANCH="copy-${TMPRANDOM}-${RELEASE_BRANCH}"
+          git push origin "$RELEASE_BRANCH:$TMPRELEASEBRANCH"
           echo "TMPRELEASEBRANCH=$TMPRELEASEBRANCH" >> $GITHUB_ENV
         env:
-          RUNGHA_RELEASE_BRANCH: ${{ env.RELEASE_BRANCH }} # just for defense against script injection
           RUNGHA_COMMIT_SHA: ${{ inputs.commitSha }} # just for defense against script injection
 
       - name: Update Version and Tag
         run: |
           # Use npm version to update version, don't create commit and tag
-          npm version --no-git-tag-version "$RUNGHA_RELEASE_VERSION"
-        env:
-          RUNGHA_RELEASE_VERSION: ${{ env.RELEASE_VERSION }} # just for defense against script injection
+          npm version --no-git-tag-version "$RELEASE_VERSION"
 
       # creates a signed commit on the tmp remote branch with our diff, and
       # then updates (fast-forward) our local branch to this new commit. It
@@ -221,11 +218,8 @@ jobs:
 
       - name: Create local tag and cleanup remote tmp branch
         run: |
-          git push origin ":$RUNGHA_TMPRELEASEBRANCH"
-          git tag "v$RUNGHA_RELEASE_VERSION"
-        env:
-          RUNGHA_TMPRELEASEBRANCH: ${{ env.TMPRELEASEBRANCH }} # just for defense against script injection
-          RUNGHA_RELEASE_VERSION: ${{ env.RELEASE_VERSION }} # just for defense against script injection
+          git push origin ":$TMPRELEASEBRANCH"
+          git tag "v$RELEASE_VERSION"
 
       - name: Install Dependencies
         run: npm ci
@@ -254,11 +248,8 @@ jobs:
 
       - name: Push release branch and tag
         run: |
-          git push origin "$RUNGHA_RELEASE_BRANCH"
-          git push origin "v$RUNGHA_RELEASE_VERSION"
-        env:
-          RUNGHA_RELEASE_BRANCH: ${{ env.RELEASE_BRANCH }} # just for defense against script injection
-          RUNGHA_RELEASE_VERSION: ${{ env.RELEASE_VERSION }} # just for defense against script injection
+          git push origin "$RELEASE_BRANCH"
+          git push origin "v$RELEASE_VERSION"
 
       - name: Checkout main
         run: |
@@ -272,12 +263,10 @@ jobs:
       - name: Extract current version
         run: |
           regex="(.*)-SNAPSHOT"
-          if [[ $RUNGHA_CURRENT_NPM_VERSION =~ $regex ]];
+          if [[ $CURRENT_NPM_VERSION =~ $regex ]];
           then
             echo "CURRENT_RELEASE_VERSION=${BASH_REMATCH[1]}" >> $GITHUB_ENV
           fi
-        env:
-          RUNGHA_CURRENT_NPM_VERSION: ${{ env.CURRENT_NPM_VERSION }} # just for defense against script injection
 
       - name: Prepare Update SNAPSHOT version on main (tmp branch for signed commit)
         if: env.CURRENT_RELEASE_VERSION == env.RELEASE_VERSION
@@ -286,11 +275,9 @@ jobs:
           # random prefix so that it's not protected, but keep release information to give context
           # can't be protected because the github commit API doesn't allow to create a commit on
           # protected branch even though we have bypass rights for the token of the app
-          TMPMAINBRANCH="copy-${TMPRANDOM}-main-${RUNGHA_RELEASE_BRANCH}"
+          TMPMAINBRANCH="copy-${TMPRANDOM}-main-${RELEASE_BRANCH}"
           git push origin "main:$TMPMAINBRANCH"
           echo "TMPMAINBRANCH=$TMPMAINBRANCH" >> $GITHUB_ENV
-        env:
-          RUNGHA_RELEASE_BRANCH: ${{ env.RELEASE_BRANCH }} # just for defense against script injection
 
       - name: Update SNAPSHOT version on main
         if: env.CURRENT_RELEASE_VERSION == env.RELEASE_VERSION
@@ -320,7 +307,5 @@ jobs:
       - name: push to main and cleanup remote tmp branch
         if: env.CURRENT_RELEASE_VERSION == env.RELEASE_VERSION
         run: |
-          git push origin ":${RUNGHA_TMPMAINBRANCH}"
+          git push origin ":${TMPMAINBRANCH}"
           git push origin main
-        env:
-          RUNGHA_TMPMAINBRANCH: ${{ env.TMPMAINBRANCH }} # just for defense against script injection

--- a/.github/workflows/release-frontend-lib-generic.yml
+++ b/.github/workflows/release-frontend-lib-generic.yml
@@ -141,13 +141,10 @@ jobs:
 
       - name: push to main and cleanup remote tmp branch
         run: |
-          git push origin ":${RUNGHA_TMPMAINBRANCH}"
+          git push origin ":${TMPMAINBRANCH}"
           git push origin main
-          git tag "v$RUNGHA_RELEASE_VERSION" main
-          git push origin "v$RUNGHA_RELEASE_VERSION"
-        env:
-          RUNGHA_TMPMAINBRANCH: ${{ env.TMPMAINBRANCH }} # just for defense against script injection
-          RUNGHA_RELEASE_VERSION: ${{ env.RELEASE_VERSION }} # just for defense against script injection
+          git tag "v$RELEASE_VERSION" main
+          git push origin "v$RELEASE_VERSION"
 
       - name: Install Dependencies
         run: npm ci

--- a/.github/workflows/release-sources-generic.yml
+++ b/.github/workflows/release-sources-generic.yml
@@ -171,23 +171,15 @@ jobs:
 
       - name: Checkout with new branch
         run: |
-          git checkout -b "release-v${RUNGHA_GITHUB_MAJOR_VERSION}.${RUNGHA_GITHUB_MINOR_VERSION}" "$RUNGHA_GIT_REFERENCE"
+          git checkout -b "release-v${GITHUB_MAJOR_VERSION}.${GITHUB_MINOR_VERSION}" "$RUNGHA_GIT_REFERENCE"
         env:
-          RUNGHA_GITHUB_MAJOR_VERSION: ${{ env.GITHUB_MAJOR_VERSION }} # just for defense against script injection
-          RUNGHA_GITHUB_MINOR_VERSION: ${{ env.GITHUB_MINOR_VERSION }} # just for defense against script injection
           RUNGHA_GIT_REFERENCE: ${{ inputs.gitReference }} # just for defense against script injection
 
       - name: Create tag
         run: |
-          git tag "v$RUNGHA_GITHUB_SHORT_VERSION"
-        env:
-          RUNGHA_GITHUB_SHORT_VERSION: ${{ env.GITHUB_SHORT_VERSION }} # just for defense against script injection
+          git tag "v$GITHUB_SHORT_VERSION"
 
       - name: Push release branch and tag
         run: |
-          git push origin "release-v${RUNGHA_GITHUB_MAJOR_VERSION}.${RUNGHA_GITHUB_MINOR_VERSION}"
-          git push origin "v$RUNGHA_GITHUB_SHORT_VERSION"
-        env:
-          RUNGHA_GITHUB_MAJOR_VERSION: ${{ env.GITHUB_MAJOR_VERSION }} # just for defense against script injection
-          RUNGHA_GITHUB_MINOR_VERSION: ${{ env.GITHUB_MINOR_VERSION }} # just for defense against script injection
-          RUNGHA_GITHUB_SHORT_VERSION: ${{ env.GITHUB_SHORT_VERSION }} # just for defense against script injection
+          git push origin "release-v${GITHUB_MAJOR_VERSION}.${GITHUB_MINOR_VERSION}"
+          git push origin "v$GITHUB_SHORT_VERSION"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
cleanup


**What is the current behavior?**
<!-- You can also link to an open issue here -->
env values are copied from X to RUNGHA_X like so:
 RUNGHA_GITHUB_SHORT_VERSION: ${{ env.GITHUB_SHORT_VERSION }} # just for defense against script injection


**What is the new behavior (if this is a feature change)?**
values are used directly


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Copying to env is only useful for {{ inputs. }} or {{ secrets. }}