### PR TITLE
quote args in case they have whitespace

### DIFF
--- a/.github/workflows/release-backend-app-generic.yml
+++ b/.github/workflows/release-backend-app-generic.yml
@@ -281,7 +281,7 @@ jobs:
         run: |
           minor=$GITHUB_MINOR_VERSION 
           ((++minor))
-          mvn --batch-mode versions:set -DgenerateBackupPoms=false -DnewVersion=$GITHUB_MAJOR_VERSION.$minor.0-SNAPSHOT
+          mvn --batch-mode versions:set -DgenerateBackupPoms=false -DnewVersion="$GITHUB_MAJOR_VERSION.$minor.0-SNAPSHOT"
           echo "MAIN_MINOR=$minor" >> $GITHUB_ENV
 
       # creates a signed commit on the tmp remote branch with our diff, and


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
chore


**What is the current behavior?**
<!-- You can also link to an open issue here -->
argument not quoted in shell, allows injections, word splitting, etc.
Shouldn't happen in reality, this variable is a version number with only alphanumeric and dots and dash


**What is the new behavior (if this is a feature change)?**
quoted, safer


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
This is not likely but a best practice and prevents mistakes like #55
