### PR TITLE
frontends with npm publish: add checks for permission before committing

### DIFF
--- a/.github/workflows/release-frontend-lib-generic.yml
+++ b/.github/workflows/release-frontend-lib-generic.yml
@@ -111,6 +111,32 @@ jobs:
           node-version: 22
           registry-url: https://registry.npmjs.org
 
+      - name: check npm publish rights
+        run: |
+          NPMUSER=$(npm whoami)
+          # NOTE: when using --json, the [[<user>]] arg is ignored and all users are returned (npm 10.9.2)
+          # it's still better to use json than parsing human readable data which may change and to guard
+          # against a user with a weird username like having a colon or whitespace or even "read-write" in its name.
+          # Example invocations:
+          #   $ npm access list collaborators mypackage myuser
+          #   myuser: read-write
+          # vs
+          #   $ npm access list collaborators mypackage myuser --json
+          #   {
+          #     "otheruser": "read-write",
+          #     "myuser": "read-write"
+          #   }
+          # NOTE: need to correctly pass the username as data to the jq script to avoid injections
+          # NOTE: this fails with automation tokens, but works without any auth! hence --userconfig /dev/null
+          NPMACCESS=$(npm --userconfig /dev/null access list collaborators --json | jq -r --arg NPMUSER "$NPMUSER" '.[$NPMUSER]')
+          # As per the docs, "Access is either read-write or read-only."
+          # only proceed if everything goes perfectly and we have read-write
+          # NOTE: If npm ever adds more roles like "admin" which should rightfully be
+          # allowed to release, we will have to revisit this, maybe they will
+          # provide a boolean map of permissions instead of just an access name
+          # like github for the actor permission?
+          [[ "$NPMACCESS" == "read-write" ]] || exit 1
+
       - name: Version and Release, push tmp branch for signed commit
         run: |
           # Use npm version to update version, don't create commit and tag, get version output vX.Y.Z


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
no


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
bad token leads to failed npm publish but branches and tags have been pushed to github and need to be manually cleaned up


**What is the new behavior (if this is a feature change)?**
check before pushing that the permission should work.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->



**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
This should reduce the number of instances where publishing to npm failed and we have to cleanup branches, tags on github
