### PR TITLE
Set fetch-depth: 0 to the Checkout github action to fix sonar analysis changed files collection

### DIFF
--- a/.github/workflows/build-frontend-app-generic.yml
+++ b/.github/workflows/build-frontend-app-generic.yml
@@ -59,6 +59,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4 v4.2.2
         with:
           persist-credentials: false
+          # Disabling shallow clones is recommended for improving the relevancy of reporting
+          fetch-depth: 0
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4 v4.3.0
         with:
           node-version: 22

--- a/.github/workflows/build-frontend-lib-generic.yml
+++ b/.github/workflows/build-frontend-lib-generic.yml
@@ -44,6 +44,8 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4 v4.2.2
         with:
           persist-credentials: false
+          # Disabling shallow clones is recommended for improving the relevancy of reporting
+          fetch-depth: 0
 
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4 v4.3.0
         with:


### PR DESCRIPTION
seeing warning : 
```
14:30:07.063 INFO  SCM collecting changed files in the branch
14:30:07.065 WARN  Could not find ref: main in refs/heads, refs/remotes/upstream or refs/remotes/origin
14:30:07.068 INFO  SCM collecting changed files in the branch (done) | time=6ms
```
then see : https://github.com/actions/checkout

> Number of commits to fetch. 0 indicates all history for all branches and tags.
> Default: 1
>     fetch-depth: ''

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
set checkout options to insure good changed files collection by sonar like specified in their action documentation


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Bad changed files computation


**What is the new behavior (if this is a feature change)?**
Correct one


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No