### PR TITLE
backend-app, frontend-app: add next tag during releases for prettier git describe on main

### DIFF
--- a/.github/workflows/release-backend-app-generic.yml
+++ b/.github/workflows/release-backend-app-generic.yml
@@ -190,7 +190,6 @@ jobs:
       - name: Checkout with new branch, push tmp branch for signed commit
         run: |
           git checkout -b "release-v${GITHUB_MAJOR_VERSION}.${GITHUB_MINOR_VERSION}" "$RUNGHA_GIT_REFERENCE"
-          git tag "base-v${GITHUB_MAJOR_VERSION}.${GITHUB_MINOR_VERSION}"
           TMPRANDOM="$(printf "%04x" $RANDOM)$(printf "%04x" $RANDOM)$(printf "%04x" $RANDOM)"
           # random prefix so that it's not protected, but keep release information to give context
           # can't be protected because the github commit API doesn't allow to create a commit on
@@ -246,7 +245,7 @@ jobs:
       - name: Push release branch and tag
         run: |
           git push origin "release-v${GITHUB_MAJOR_VERSION}.${GITHUB_MINOR_VERSION}"
-          git push origin "v$GITHUB_SHORT_VERSION" "base-v${GITHUB_MAJOR_VERSION}.${GITHUB_MINOR_VERSION}"
+          git push origin "v$GITHUB_SHORT_VERSION"
 
       - name: Checkout main
         run: |
@@ -301,5 +300,7 @@ jobs:
       - name: push to main and cleanup remote tmp branch
         if: env.CURRENT_RELEASE_VERSION == env.GITHUB_SHORT_VERSION
         run: |
+          next_tag="next-v$GITHUB_MAJOR_VERSION.$MAIN_MINOR"
+          git tag "$next_tag"
           git push origin ":${TMPMAINBRANCH}"
-          git push
+          git push origin main "$next_tag"

--- a/.github/workflows/release-frontend-app-generic.yml
+++ b/.github/workflows/release-frontend-app-generic.yml
@@ -116,7 +116,6 @@ jobs:
           echo "RELEASE_MINOR_VERSION=${MINOR}" >> $GITHUB_ENV
           echo "RELEASE_VERSION=${MAJOR}.${MINOR}.0" >> $GITHUB_ENV
           echo "RELEASE_BRANCH=release-v${MAJOR}.${MINOR}" >> $GITHUB_ENV
-          echo "BASE_TAG=base-v${MAJOR}.${MINOR}" >> $GITHUB_ENV
         env:
           RUNGHA_RELEASE_VERSION: ${{ inputs.releaseVersion }} # just for defense against script injection
 
@@ -189,7 +188,6 @@ jobs:
       - name: Create Release Branch, push tmp branch for signed commit
         run: |
           git checkout -b "$RELEASE_BRANCH" "$RUNGHA_COMMIT_SHA"
-          git tag "$BASE_TAG"
 
           TMPRANDOM="$(printf "%04x" $RANDOM)$(printf "%04x" $RANDOM)$(printf "%04x" $RANDOM)"
           # random prefix so that it's not protected, but keep release information to give context
@@ -251,7 +249,7 @@ jobs:
       - name: Push release branch and tag
         run: |
           git push origin "$RELEASE_BRANCH"
-          git push origin "v$RELEASE_VERSION" "$BASE_TAG"
+          git push origin "v$RELEASE_VERSION"
 
       - name: Checkout main
         run: |
@@ -286,11 +284,13 @@ jobs:
         run: |
           # Calculate next development version
           NEW_MINOR=$((RELEASE_MINOR_VERSION + 1))
-          DEV_VERSION="${RELEASE_MAJOR_VERSION}.${NEW_MINOR}.0-SNAPSHOT"
+          NEXT_MAJORMINOR="${RELEASE_MAJOR_VERSION}.${NEW_MINOR}"
+          DEV_VERSION="${NEXT_MAJORMINOR}.0-SNAPSHOT"
           
           # Update package.json with development version
           npm version ${DEV_VERSION} --no-git-tag-version
           
+          echo "NEXT_MAJORMINOR=$NEXT_MAJORMINOR" >> $GITHUB_ENV
           echo "DEV_VERSION=$DEV_VERSION" >> $GITHUB_ENV
 
       # creates a signed commit on the tmp remote branch with our diff, and
@@ -309,5 +309,7 @@ jobs:
       - name: push to main and cleanup remote tmp branch
         if: env.CURRENT_RELEASE_VERSION == env.RELEASE_VERSION
         run: |
+          next_tag="next-v$NEXT_MAJORMINOR"
+          git tag "$next_tag"
           git push origin ":${TMPMAINBRANCH}"
-          git push origin main
+          git push origin main "$next_tag"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
NO


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
feature/bugfix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
git describe in main on projects using these workflow shows  an old version (or nothing if there was never a tag on main)


**What is the new behavior (if this is a feature change)?**
git describe in main show the latest release version as "next-2.18" for exemple


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
Because we can release not at the tip of main but a few commits below, we never have a tag on main corresponding to the point where we branched. As a simplest solution, add a tag from now on. An alternative would be to merge the released tagged commit in main so that we have the real release tag in git describe, but this means we don't have linear history. Not sure what is best.
We could add a tag "base-v2.18" at the commit where we branch for v2.18, but then the git describe during the whole next iteration (preparing for v2.19) will show v2.18. So instead, we add a tag "next-v2.19" at the versionbump commit

