### PR TITLE
Add eslint to Quality Checks step for fontends build workflows.

### DIFF
--- a/.github/workflows/build-frontend-app-generic.yml
+++ b/.github/workflows/build-frontend-app-generic.yml
@@ -70,6 +70,7 @@ jobs:
 
       - name: Quality Checks
         run: |
+          npm run lint
           npm run test:coverage
           npm run licenses-check
 

--- a/.github/workflows/build-frontend-lib-generic.yml
+++ b/.github/workflows/build-frontend-lib-generic.yml
@@ -56,6 +56,7 @@ jobs:
 
       - name: Quality Checks
         run: |
+          npm run lint
           npm run test:coverage
           npm run licenses-check
 

--- a/.github/workflows/release-frontend-app-generic.yml
+++ b/.github/workflows/release-frontend-app-generic.yml
@@ -226,6 +226,7 @@ jobs:
 
       - name: Quality Checks
         run: |
+          npm run lint
           npm run test:coverage
           npm run licenses-check
 


### PR DESCRIPTION
feat(frontend builds): Add `npm run lint` to   Quality Checks step, because eslint will be remove from vite config extensions and then ignored during `npm run build`

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
feature


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Currently `npm run build` execute eslint as a vite extension declared in vite config.
We want to remove the eslint extension from vite config in our frontends projects then we should call eslint independently.


**What is the new behavior (if this is a feature change)?**
eslint is still executed but separately.


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
Nothing or remove eslint extension from their main vite config file.
At worse it will lint two times.
