### PR TITLE
Add release-frontend-lib-trusted for npmjs trusted publisher

### DIFF
--- a/.github/workflows/release-frontend-lib-trusted-generic.yml
+++ b/.github/workflows/release-frontend-lib-trusted-generic.yml
@@ -98,7 +98,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4 v4.3.0
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org
 
       - name: Version and Release, push tmp branch for signed commit


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Manage Npm Trusted Publishing https://docs.npmjs.com/trusted-publishers

Note : we don't need `--provenance` param anymore
see https://docs.npmjs.com/trusted-publishers#automatic-provenance-generation


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Npm publish used NODE AUTH_TOKEN


**What is the new behavior (if this is a feature change)?**
Workflow and github repository should be declared as Trusted Publisher on Npmjs.com


**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
Workflow and github repository should be declared as Trusted Publisher on Npmjs.com
Alternative to passing the NODE_AUTH_TOKEN, but needs support
from npmjs.com: https://docs.npmjs.com/trusted-publishers

Copied from release-backend-lib-generic but with node24 (for npm11+)
and without the parts checking the npm rights (removing the human
account is the whole point of this system).

Note that the packages are now published on npmjs.com with this information:
  
$ npm view XXX
published 24 minutes ago by GitHub Actions <npm-oidc-no-reply@github.com>

tested with and without a required environment, everything behaves correctly:
- without environment on npmjs.com, works with anything on githubaction
- with environment "foo" on npmjs.com and no environment enabled in the githubaction => rejected
- with environment "foo" on npmjs.com and environment "bar" enabled in the githubaction => rejected

Interoperates correctly with restricted environment to branches => only safe code that checks for maintainer permission in bash from the workflow file on main branch can publish.

Note: watch out, if you didn't create the environment on github beforehand (with appropriate branch/tag restrictions), running a github action will create it without any restriction (it contains no secrets, but npm publish doesn't need any secret)


Signed-off-by: HARPER Jon <jon.harper87@gmail.com>
