### PR TITLE
Use DOCKERHUB_TOKEN instead of DOCKER_RELEASE 

### DIFF
--- a/.github/workflows/manual-dockerdeploy-backend-app-generic.yml
+++ b/.github/workflows/manual-dockerdeploy-backend-app-generic.yml
@@ -12,7 +12,7 @@ on:
         default: 'release'
         type: string
     secrets:
-      DOCKER_RELEASE:
+      DOCKERHUB_TOKEN:
         required: true
 
 jobs:
@@ -80,8 +80,8 @@ jobs:
           -Djib.httpTimeout=60000
           ${RUNGHA_DOCKER_IMAGE:+-Djib.to.image="$RUNGHA_DOCKER_IMAGE:$CURRENT_TAG_VERSION"}
           -Djib.to.auth.username="$RUNGHA_DOCKER_USERNAME"
-          -Djib.to.auth.password="$RUNGHA_DOCKER_RELEASE"
+          -Djib.to.auth.password="$RUNGHA_DOCKERHUB_TOKEN"
         env:
           RUNGHA_DOCKER_IMAGE: ${{ inputs.dockerImage }} # just for defense against script injection
           RUNGHA_DOCKER_USERNAME: ${{ inputs.dockerUsername }} # just for defense against script injection
-          RUNGHA_DOCKER_RELEASE: ${{ secrets.DOCKER_RELEASE }} # just for defense against script injection
+          RUNGHA_DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }} # just for defense against script injection


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines



**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Consistency with other actions that use DOCKERHUB_TOKEN


**What is the current behavior?**
<!-- You can also link to an open issue here -->
manual-dockerdeploy-backend-app-generic.yml use DOCKER_RELEASE


**What is the new behavior (if this is a feature change)?**
manual-dockerdeploy-backend-app-generic.yml use DOCKERHUB_TOKEN
